### PR TITLE
use github.com/urfave/cli as import

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,7 @@ require (
 	github.com/mattn/go-isatty v0.0.9 // indirect
 	github.com/myesui/uuid v1.0.0 // indirect
 	github.com/peterbourgon/mergemap v0.0.0-20130613134717-e21c03b7a721
+	github.com/urfave/cli v1.20.0
 	gopkg.in/fatih/color.v1 v1.7.0
 	gopkg.in/myesui/uuid.v1 v1.0.0
-	gopkg.in/stretchr/testify.v1 v1.4.0 // indirect
-	gopkg.in/urfave/cli.v1 v1.20.0
 )
-
-replace gopkg.in/stretchr/testify.v1 => github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
+github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a h1:aYOabOQFp6Vj6W1F80affTUvO9UxmJRx8K0gsfABByQ=
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -25,7 +27,5 @@ gopkg.in/fatih/color.v1 v1.7.0 h1:bYGjb+HezBM6j/QmgBfgm1adxHpzzrss6bj4r9ROppk=
 gopkg.in/fatih/color.v1 v1.7.0/go.mod h1:P7yosIhqIl/sX8J8UypY5M+dDpD2KmyfP5IRs5v/fo0=
 gopkg.in/myesui/uuid.v1 v1.0.0 h1:9y1k4tTQvYr0GliMtqWdBxMEX3X86gow12Uj6GIyBiE=
 gopkg.in/myesui/uuid.v1 v1.0.0/go.mod h1:OHnLC+jZGuFVkJVF3gLeL7pqB+S6rx0NlvgLqclsWc4=
-gopkg.in/urfave/cli.v1 v1.20.0 h1:NdAVW6RYxDif9DhDHaAortIu956m2c0v+09AZBPTbE0=
-gopkg.in/urfave/cli.v1 v1.20.0/go.mod h1:vuBzUtMdQeixQj8LVd+/98pzhxNGQoyuPBlsXHOQNO0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -16,8 +16,8 @@ pkg_bin_dirs=(bin)
 scaffolding_go_base_path="github.com/screwdriver-cd"
 scaffolding_go_build_deps=(
     github.com/creack/pty
+    github.com/urfave/cli
     gopkg.in/myesui/uuid.v1
-    gopkg.in/urfave/cli.v1
     gopkg.in/fatih/color.v1
 )
 

--- a/launch.go
+++ b/launch.go
@@ -17,8 +17,8 @@ import (
 	"github.com/peterbourgon/mergemap"
 	"github.com/screwdriver-cd/launcher/executor"
 	"github.com/screwdriver-cd/launcher/screwdriver"
+	"github.com/urfave/cli"
 	"gopkg.in/fatih/color.v1"
-	"gopkg.in/urfave/cli.v1"
 )
 
 // These variables get set by the build script via the LDFLAGS


### PR DESCRIPTION
PR-to-PR github.com/urfave/cli removes unnecessary `replace` and changes the import from `gopkg.in/urfave/cli.v1` to `github.com/urfave/cli ` as recommended by the repo developer in https://github.com/urfave/cli#using-v1-releases.

@scr-oath - please notice that the unit tests fail when run locally:
```
$ go test -v -run TestUpdateStepStart github.com/screwdriver-cd/launcher/screwdriver
=== RUN   TestUpdateStepStart
--- FAIL: TestUpdateStepStart (0.00s)
    screwdriver_test.go:465: buf.String() = "{\"startTime\":\"2019-09-20T10:48:47.31275+02:00\"}"
FAIL
FAIL	github.com/screwdriver-cd/launcher/screwdriver	0.070s
FAIL
```
- also `data/emitter` is getting changed on a test run which makes commiting with `git commit -a` more difficult, or can lead to picking up spurious changes:
```
$ git diff
diff --git a/data/emitter b/data/emitter
index a15fbc7..620545c 100644
--- a/data/emitter
+++ b/data/emitter
@@ -1,9 +1,9 @@
-{"t":1551828841797,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
-{"t":1551828841797,"m":"Version:        vdev","s":"sd-setup-launcher"}
-{"t":1551828841797,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
-{"t":1551828841797,"m":"Job:            main","s":"sd-setup-launcher"}
-{"t":1551828841797,"m":"Build:          #1","s":"sd-setup-launcher"}
-{"t":1551828841797,"m":"Workspace Dir:  /var/folders/1d/cbhf8kbn5j1fjvjblbx03vhc0000gn/T/ArtifactDir248813989","s":"sd-setup-launcher"}
-{"t":1551828841797,"m":"Source Dir:     /var/folders/1d/cbhf8kbn5j1fjvjblbx03vhc0000gn/T/ArtifactDir248813989/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
-{"t":1551828841798,"m":"Artifacts Dir:  /var/folders/1d/cbhf8kbn5j1fjvjblbx03vhc0000gn/T/ArtifactDir248813989/artifacts","s":"sd-setup-launcher"}
-8209834,"m":"\u001b[90mArtifacts Dir:  \u001b[0m/var/folders/1d/cbhf8kbn5j1fjvjblbx03vhc0000gn/T/ArtifactDir859542109/artifacts","s":"sd-setup-launcher"}
+{"t":1568969003684,"m":"Screwdriver Launcher information","s":"sd-setup-launcher"}
+{"t":1568969003684,"m":"Version:        vdev","s":"sd-setup-launcher"}
+{"t":1568969003684,"m":"Pipeline:       #3","s":"sd-setup-launcher"}
+{"t":1568969003684,"m":"Job:            main","s":"sd-setup-launcher"}
+{"t":1568969003684,"m":"Build:          #1","s":"sd-setup-launcher"}
+{"t":1568969003684,"m":"Workspace Dir:  /var/folders/nx/38wtfs5x7kn1jt6t6rhdl67c0000gp/T/ArtifactDir703971804","s":"sd-setup-launcher"}
+{"t":1568969003685,"m":"Checkout Dir:     /var/folders/nx/38wtfs5x7kn1jt6t6rhdl67c0000gp/T/ArtifactDir703971804/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1568969003685,"m":"Source Dir:     /var/folders/nx/38wtfs5x7kn1jt6t6rhdl67c0000gp/T/ArtifactDir703971804/src/github.com/screwdriver-cd/launcher","s":"sd-setup-launcher"}
+{"t":1568969003685,"m":"Artifacts Dir:  /var/folders/nx/38wtfs5x7kn1jt6t6rhdl67c0000gp/T/ArtifactDir703971804/artifacts","s":"sd-setup-launcher"}
```